### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,19 @@
   "directories": {
     "test": "test"
   },
-  "dependencies": {
+  "peerDependencies": {
     "knockout": "~3.2.0",
-    "jasmine-reporters": "~0.2.1"
   },
   "devDependencies": {
+    "knockout": "~3.2.0",
     "grunt": "~0.4.1",
     "grunt-contrib-jshint": "~0.4.3",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-watch": "~0.4.3",
     "grunt-jasmine-node": "~0.1.0",
-    "grunt-string-replace": "~0.2.7"
+    "grunt-string-replace": "~0.2.7",
+    "jasmine-reporters": "~0.2.1"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
`jasmine-reporters` should be a dev dependency so it isn't installed for users of this package.

`knockout` should be a peer dependency so that inconsistent versions give errors instead of silently including multiple copies.

For example, currently the following dependencies will result in 2 copies of knockout being included, and only one (the one you can't reference from anywhere else) will have the projection enhancements added to it:

``` js
{
  "dependencies": {
    "knockout": "~3.1.0",
    "one-com-knockout-projections": "^1.6.0"
  }
}
```
